### PR TITLE
update jkt#S256 to reflect the used key

### DIFF
--- a/mainmatter.md
+++ b/mainmatter.md
@@ -276,7 +276,7 @@ key to which the access token is bound.
     "exp": 1503726400,
     "nbf": 1503722800,
     "cnf":{
-        "jkt#S256": "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+        "jkt#S256": "oKIywvGUpTVTyxMQ3bwIIeQUudfr_CkLMjCE19ECD-U"
     }
 }
 ```


### PR DESCRIPTION
This updates the shown non-normative example `jkt#S256` to reflect the key used in Figure 2.

```js
const { JWK } = require('@panva/jose')
const key = JWK.asKey({"kty": "EC","crv": "P-256", "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU","y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"})
key.thumbprint
// 'oKIywvGUpTVTyxMQ3bwIIeQUudfr_CkLMjCE19ECD-U'
```