### PR TITLE
rework text around uniqueness requirements on the jti claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,14 @@ a public/private key pair.
 
 Written in markdown for the [mmark processor](https://github.com/mmarkdown/mmark).
 
-Compiling: `mmark -2 main.md > draft.xml; xml2rfc --legacy --html draft.xml`
+## Compiling
+
+### using Docker
+From the root of this repository, run
+```bash
+docker run -v `pwd`:/data danielfett/markdown2rfc
+```
+(see https://github.com/oauthstuff/markdown2rfc)
+
+### without Docker
+compile using mmark and xml2rfc: `mmark -2 main.md > draft.xml; xml2rfc --legacy --html draft.xml`

--- a/documenthistory.md
+++ b/documenthistory.md
@@ -4,7 +4,7 @@
 
    -03 
    
-   * rework the text around uniqueness requirements on the jti claim in the DPoP proof JWT
+   * make the jti claim optional and rework the text around its uniqueness requirements while moving to have the server track a hash of the full JWT for replay prevention 
 
    -02
    

--- a/documenthistory.md
+++ b/documenthistory.md
@@ -4,7 +4,7 @@
 
    -03 
    
-   * make the jti claim optional and rework the text around its uniqueness requirements while moving to have the server track a hash of the full JWT for replay prevention 
+   * rework the text around uniqueness requirements on the jti claim in the DPoP proof JWT
 
    -02
    

--- a/documenthistory.md
+++ b/documenthistory.md
@@ -2,6 +2,10 @@
 
    [[ To be removed from the final specification ]]
 
+   -03 
+   
+   * rework the text around uniqueness requirements on the jti claim in the DPoP proof JWT
+
    -02
    
    * added normalization rules for URIs

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -332,10 +332,10 @@ could replay that token at the same endpoint (the HTTP endpoint
 and method are enforced via the respective claims in the JWTs). To
 prevent this, servers MUST only accept DPoP proofs for a limited time
 window after their `iat` time, preferably only for a brief period.
-Furthermore, the `jti` claim in each JWT MUST contain a globally unique
+Furthermore, the `jti` claim in each DPoP proof JWT MUST contain a globally unique
 value (e.g., 128 bits of pseudorandom data base64url encoded). 
 Servers SHOULD store the `jti` value for the time window in
-which the respective JWT would be accepted and decline HTTP requests
+which the respective DPoP proof JWT would be accepted and decline HTTP requests
 for which the `jti` value has been seen before.
 
 Note: To accommodate for clock offsets, the server MAY accept DPoP

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -109,7 +109,7 @@ The body of a DPoP proof contains at least the following claims:
    probability that the same value will be assigned to any 
    other DPoP proof used in the same context during the time window of validity.
    Such uniqueness can be accomplished by encoding (base64url or any other
-   suitable encoding) at least 128 bits of
+   suitable encoding) at least 96 bits of
    pseudorandom data or by using a version 4 UUID string according to [@RFC4122].
    The `jti` SHOULD be used by the server for replay
    detection and prevention. See (#Security) in the Security Considerations.
@@ -134,7 +134,7 @@ An example DPoP proof is shown in Figure 2.
     "crv":"P-256"
   }
 }.{
-  "jti":"-BwC3yESc04acc77lTc26x",
+  "jti":"-BwC3ESc6acc2lTc",
   "htm":"POST",
   "htu":"https://server.example.com/token",
   "iat":1562262616
@@ -192,10 +192,10 @@ Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 DPoP: eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6Ik
  VDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCR
  nMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JE
- QSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiItQndDM3lFU2MwNGFjYzc3bFRjMjZ4Ii
- wiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHBzOi8vc2VydmVyLmV4YW1wbGUuY29tL3Rva
- 2VuIiwiaWF0IjoxNTYyMjYyNjE2fQ.CFfJCMOMfCFnf7UD7ifJ3wODRcMyUQpCb5_gW
- meMGoqoIZ7HWd6x01fQtaK9Cqf6y4mplhTDhQEUllMeY_6X_A
+ QSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiItQndDM0VTYzZhY2MybFRjIiwiaHRtIj
+ oiUE9TVCIsImh0dSI6Imh0dHBzOi8vc2VydmVyLmV4YW1wbGUuY29tL3Rva2VuIiwia
+ WF0IjoxNTYyMjYyNjE2fQ.2-GxA6T8lP4vfrg8v-FdWP0A0zdrj8igiMLvqRMUvwnQg
+ 4PtFLbdLXiOSsX0x7NVY-FNyJK70nfbV37xRZT3Lg
 grant_type=authorization_code
 &code=SplxlOBeZQQYbYS6WxSbIA
 &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb
@@ -262,10 +262,10 @@ Authorization: DPoP eyJhbGciOiJFUzI1NiIsImtpZCI6IkJlQUxrYiJ9.eyJzdWI
 DPoP: eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6Ik
  VDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCR
  nMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JE
- QSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiJVZTFqM1ZFUWFWenhEa0pwT2dMQUVCIi
- wiaHRtIjoiR0VUIiwiaHR1IjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZy9wc
- m90ZWN0ZWRyZXNvdXJjZSIsImlhdCI6MTU2MjI2MjYxOH0.fywDjkV02kftSACnpXJM
- CHMLdSBs0Jg0_iiCLalHsuk60bAqry_YGBabt1r4fkBE8SKA91uDWP2i6tPkBVZOXA
+ QSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiJlMWozVl9iS2ljOC1MQUVCIiwiaHRtIj
+ oiR0VUIiwiaHR1IjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZy9wcm90ZWN0Z
+ WRyZXNvdXJjZSIsImlhdCI6MTU2MjI2MjYxOH0.lNhmpAX1WwmpBvwhok4E74kWCiGB
+ NdavjLAeevGy32H3dbF0Jbri69Nm2ukkwb-uyUI4AUg1JSskfWIyo4UCbQ
 ~~~
 !---
 Figure 4: Protected Resource Request with a DPoP sender-constrained access token.

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -107,11 +107,12 @@ The body of a DPoP proof contains at least the following claims:
  * `jti`: Unique identifier for the DPoP proof JWT (REQUIRED).
    The value MUST be assigned such that there is a negligible 
    probability that the same value will be assigned to any 
-   other DPoP proof, which can be accomplished with 128 bits of
-   pseudorandom data in base64url encoding (or any other suitable encoding),
-   or a version 4 UUID according to [@RFC4122].
+   other DPoP proof used in the same context during the time window of validity.
+   Such uniqueness can be accomplished by encoding (base64url or any other
+   suitable encoding) at least 128 bits of
+   pseudorandom data or by using a version 4 UUID string according to [@RFC4122].
    The `jti` SHOULD be used by the server for replay
-   detection and prevention. See Security Considerations, Section (#Security).
+   detection and prevention. See (#Security) in the Security Considerations.
  * `htm`: The HTTP method for the request to which the JWT is
    attached, as defined in [@!RFC7231] (REQUIRED).
  * `htu`: The HTTP URI used for the request, without query and

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -333,7 +333,7 @@ and method are enforced via the respective claims in the JWTs). To
 prevent this, servers MUST only accept DPoP proofs for a limited time
 window after their `iat` time, preferably only for a brief period.
 Furthermore, the `jti` claim in each DPoP proof JWT MUST contain a globally unique
-value (e.g., 128 bits of pseudorandom d ata base64url encoded). 
+value (e.g., 128 bits of pseudorandom data base64url encoded). 
 Servers SHOULD store the `jti` value for the time window in
 which the respective DPoP proof JWT would be accepted and decline HTTP requests
 for which the `jti` value has been seen before. In order to guard against 

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -333,10 +333,12 @@ and method are enforced via the respective claims in the JWTs). To
 prevent this, servers MUST only accept DPoP proofs for a limited time
 window after their `iat` time, preferably only for a brief period.
 Furthermore, the `jti` claim in each DPoP proof JWT MUST contain a globally unique
-value (e.g., 128 bits of pseudorandom data base64url encoded). 
+value (e.g., 128 bits of pseudorandom d ata base64url encoded). 
 Servers SHOULD store the `jti` value for the time window in
 which the respective DPoP proof JWT would be accepted and decline HTTP requests
-for which the `jti` value has been seen before.
+for which the `jti` value has been seen before. In order to guard against 
+memory exhaustion attacks a server SHOULD reject DPoP proof JWTs with unnecessarily
+large `jti` values or store only a hash thereof.    
 
 Note: To accommodate for clock offsets, the server MAY accept DPoP
 proofs that carry an `iat` time in the near future (e.g., up to one

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -107,7 +107,10 @@ The body of a DPoP proof contains at least the following claims:
  * `jti`: Unique identifier for the DPoP proof JWT (REQUIRED).
    The value MUST be assigned such that there is a negligible 
    probability that the same value will be assigned to any 
-   other DPoP proof. The `jti` SHOULD be used by the server for replay
+   other DPoP proof, which can be accomplished with 128 bits of
+   pseudorandom data in base64url encoding (or any other suitable encoding),
+   or a version 4 UUID according to [@RFC4122].
+   The `jti` SHOULD be used by the server for replay
    detection and prevention. See Security Considerations, Section (#Security).
  * `http_method`: The HTTP method for the request to which the JWT is
    attached, as defined in [@!RFC7231] (REQUIRED).
@@ -332,9 +335,7 @@ could replay that token at the same endpoint (the HTTP endpoint
 and method are enforced via the respective claims in the JWTs). To
 prevent this, servers MUST only accept DPoP proofs for a limited time
 window after their `iat` time, preferably only for a brief period.
-Furthermore, the `jti` claim in each DPoP proof JWT MUST contain a globally unique
-value (e.g., 128 bits of pseudorandom data base64url encoded). 
-Servers SHOULD store the `jti` value for the time window in
+Servers SHOULD store the `jti` value of each DPoP proof for the time window in
 which the respective DPoP proof JWT would be accepted and decline HTTP requests
 for which the `jti` value has been seen before. In order to guard against 
 memory exhaustion attacks a server SHOULD reject DPoP proof JWTs with unnecessarily

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -104,16 +104,24 @@ header of a DPoP JWT contains at least the following parameters:
    
 The body of a DPoP proof contains at least the following claims:
 
- * `jti`: Unique identifier for the DPoP proof JWT (REQUIRED).
-   The value MUST be assigned such that there is a negligible 
-   probability that the same value will be assigned to any 
-   other DPoP proof. The `jti` SHOULD be used by the server for replay
-   detection and prevention. See Security Considerations, Section (#Security).
  * `http_method`: The HTTP method for the request to which the JWT is
    attached, as defined in [@!RFC7231] (REQUIRED).
  * `http_uri`: The HTTP URI used for the request, without query and
    fragment parts (REQUIRED).
  * `iat`: Time at which the JWT was created (REQUIRED).
+ * `jti`: Contextually unique identifier for the DPoP proof JWT (OPTIONAL).
+    A `jti` value is needed only in cases where a deterministic signature algorithm 
+    is being used, which differentiates DPoP proof JWTs created during the 
+    same second with the same HTTP method and URI. When a deterministic 
+    signature algorithm is employed, the `jti` value needs to be 
+    unique in the context of the public key, HTTP method, HTTP URI, and 
+    time at which the JWT was created. Such uniqueness requirements can
+    be achieved by assigning `jti` values from a simple incrementing counter 
+    that periodically resets.    
+                                                                                 
+    
+The full DPoP proof JWT (or preferably a hash thereof) SHOULD be used by the server for replay
+detection and prevention. See (#Token_Replay) in the Security Considerations for details.
 
 
 An example DPoP proof is shown in Figure 2.
@@ -164,7 +172,7 @@ valid DPoP proof, the receiving server MUST ensure that
     fragment parts,
  1. the token was issued within an acceptable timeframe (see (#Token_Replay)), and
  1. that, within a reasonable consideration of accuracy and resource utilization,
-    a JWT with the same `jti` value has not been received
+    the same JWT value has not been received
     previously (see (#Token_Replay)).
 
 Servers SHOULD employ Syntax-Based Normalization and Scheme-Based
@@ -332,13 +340,9 @@ could replay that token at the same endpoint (the HTTP endpoint
 and method are enforced via the respective claims in the JWTs). To
 prevent this, servers MUST only accept DPoP proofs for a limited time
 window after their `iat` time, preferably only for a brief period.
-Furthermore, the `jti` claim in each DPoP proof JWT MUST contain a globally unique
-value (e.g., 128 bits of pseudorandom data base64url encoded). 
-Servers SHOULD store the `jti` value for the time window in
-which the respective DPoP proof JWT would be accepted and decline HTTP requests
-for which the `jti` value has been seen before. In order to guard against 
-memory exhaustion attacks a server SHOULD reject DPoP proof JWTs with unnecessarily
-large `jti` values or store only a hash thereof.    
+Furthermore, servers SHOULD store a hash of the full DPoP proof JWT 
+value for the time window in which it would be accepted and decline 
+HTTP requests with a DPoP proof JWT that has been seen before. 
 
 Note: To accommodate for clock offsets, the server MAY accept DPoP
 proofs that carry an `iat` time in the near future (e.g., up to one

--- a/mainmatter.md
+++ b/mainmatter.md
@@ -104,8 +104,10 @@ header of a DPoP JWT contains at least the following parameters:
    
 The body of a DPoP proof contains at least the following claims:
 
- * `jti`: Unique identifier for this JWT chosen freshly when creating
-   the DPoP proof (REQUIRED). SHOULD be used by the AS for replay
+ * `jti`: Unique identifier for the DPoP proof JWT (REQUIRED).
+   The value MUST be assigned such that there is a negligible 
+   probability that the same value will be assigned to any 
+   other DPoP proof. The `jti` SHOULD be used by the server for replay
    detection and prevention. See Security Considerations, Section (#Security).
  * `http_method`: The HTTP method for the request to which the JWT is
    attached, as defined in [@!RFC7231] (REQUIRED).
@@ -326,17 +328,17 @@ following.
 ## DPoP Proof Replay {#Token_Replay}
 
 If an adversary is able to get hold of a DPoP proof JWT, the adversary
-could replay that token later at the same endpoint (the HTTP endpoint
+could replay that token at the same endpoint (the HTTP endpoint
 and method are enforced via the respective claims in the JWTs). To
 prevent this, servers MUST only accept DPoP proofs for a limited time
 window after their `iat` time, preferably only for a brief period.
-Furthermore, the `jti` claim in each JWT MUST contain a unique
-(incrementing or randomly chosen) value, as proposed in [@!RFC7253].
-Resource servers SHOULD store values at least for the time window in
-which the respective JWT is accepted and decline HTTP requests by
-clients if a `jti` value has been seen before.
+Furthermore, the `jti` claim in each JWT MUST contain a globally unique
+value (e.g., 128 bits of pseudorandom data base64url encoded). 
+Servers SHOULD store the `jti` value for the time window in
+which the respective JWT would be accepted and decline HTTP requests
+for which the `jti` value has been seen before.
 
-Note: To acommodate for clock offsets, the server MAY accept DPoP
+Note: To accommodate for clock offsets, the server MAY accept DPoP
 proofs that carry an `iat` time in the near future (e.g., up to one
 second in the future).
 


### PR DESCRIPTION
rework the text around uniqueness requirements on the jti claim in the DPoP proof JWT to fix issue #47