### PR TITLE
Use only no-store as a value for the Cache-Control header in examples.

### DIFF
--- a/main.md
+++ b/main.md
@@ -460,7 +460,7 @@ response.
 ~~~
 HTTP/1.1 200 OK
 Content-Type: application/json
-Cache-Control: no-cache, no-store
+Cache-Control: no-store
 
 {
  "access_token": "Kz~8mXK1EalYznwH-LC-1fBAo.4Ljp~zsPE_NeO.gxU",
@@ -645,7 +645,7 @@ Figure: Example Introspection Request {#introspect-req}
 ```
 HTTP/1.1 200 OK
 Content-Type: application/json
-Cache-Control: no-cache, no-store
+Cache-Control: no-store
 
 {
   "active": true,


### PR DESCRIPTION
I'm wondering what are the reasons to use both cache directives at the same time. This PR leaves only `no-store` that IMO should be sufficient.