### PR TITLE
add "(such as ES256)" 

### DIFF
--- a/main.md
+++ b/main.md
@@ -1250,7 +1250,7 @@ for other purposes.
 
 ## Signature Algorithms
 
-Implementers MUST ensure that only asymmetric digital signature algorithms that
+Implementers MUST ensure that only asymmetric digital signature algorithms (such as `ES256`) that
 are deemed secure can be used for signing DPoP proofs. In particular,
 the algorithm `none` MUST NOT be allowed.
 


### PR DESCRIPTION
Added parenthetical remark "(such as ES256)" to Signature Algorithms subsection per side meeting discussion at IEFT 114 on shepherd review items